### PR TITLE
Remove "literal" definition from chunking_strategy

### DIFF
--- a/prepline_general/api/models/form_params.py
+++ b/prepline_general/api/models/form_params.py
@@ -177,10 +177,10 @@ class GeneralFormParams(BaseModel):
         ] = False,
         # -- chunking options --
         chunking_strategy: Annotated[
-            Optional[Literal["by_title"]],
+            Optional[str],
             Form(
                 title="Chunking Strategy",
-                description="Use one of the supported strategies to chunk the returned elements. Currently supports: by_title",
+                description="Use one of the supported strategies to chunk the returned elements.",
                 examples=["by_title"],
             ),
         ] = None,


### PR DESCRIPTION
This makes it easier to add additional strategies.  These are already validated in the code, so the Pydantic check is unnecessary (and much harder to override).